### PR TITLE
Update model endpoints in librechat-env.yaml

### DIFF
--- a/librechat-env.yaml
+++ b/librechat-env.yaml
@@ -89,6 +89,8 @@ endpoints:
           - google/gemini-1.5-pro-latest
           - google/gemini-2.0-flash-001
           - google/gemini-2.0-flash-exp
+          - google/gemini-2.0-flash-thinking-exp-01-21
+          - google/gemini-2.5-pro-exp-03-25
           - groq/qwen-qwq-32b
           - minimaxi/DeepSeek-R1
           - minimaxi/MiniMax-Text-01
@@ -100,14 +102,19 @@ endpoints:
           - nebius/deepseek-ai/DeepSeek-R1
           - nebius/deepseek-ai/DeepSeek-R1-fast
           - nebius/deepseek-ai/DeepSeek-V3
+          - nebius/deepseek-ai/DeepSeek-V3-0324
+          - nebius/deepseek-ai/DeepSeek-V3-0324-fast
           - nebius/meta-llama/Llama-3.3-70B-Instruct
           - novita/Sao10K/L3-8B-Stheno-v3.2
           - novita/cognitivecomputations/dolphin-mixtral-8x22b
           - novita/deepseek/deepseek-r1
+          - novita/deepseek/deepseek-r1-turbo
           - novita/deepseek/deepseek-r1-distill-llama-70b
           - novita/deepseek/deepseek-r1-distill-llama-8b
           - novita/deepseek/deepseek-r1-distill-qwen-14b
           - novita/deepseek/deepseek-r1-distill-qwen-32b
+          - novita/deepseek/deepseek-v3-turbo
+          - novita/deepseek/deepseek-v3-0324
           - novita/deepseek/deepseek_v3
           - novita/google/gemma-2-9b-it
           - novita/gryphe/mythomax-l2-13b
@@ -161,6 +168,9 @@ endpoints:
           - parasail/parasail-qwen25-vl-72b-instruct
           - parasail/parasail-skyfall-36b-v2-fp8
           - parasail/parasail-wayfarer-70b-llama33-fp8
+          - perplexity/sonar-pro
+          - perplexity/sonar-reasoning-pro
+          - perplexity/sonar
           - together/NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO
           - together/Qwen/QwQ-32B-Preview
           - together/Qwen/Qwen2-72B-Instruct


### PR DESCRIPTION
I've added some of the new models since the last change to this yaml a few weeks ago. 

The names came from https://app.requesty.ai/router/list.

I don't know if I got every single change but I think I got all the big new ones (Gemini 2.5, Perplexity, some of the new DeepSeek models from novita/nebius).

I did not change deepseek/deepseek-chat because the new DeepSeek v3 0324 is already pointed to that name.